### PR TITLE
use zope.interface.implementer decorator for py3 compatibility

### DIFF
--- a/txgsm/service.py
+++ b/txgsm/service.py
@@ -1,6 +1,6 @@
 # -*- test-case-name: txgsm.tests.test_service -*-
 import sys
-from zope.interface import implements
+from zope.interface import implementer
 
 from twisted.python import usage
 from twisted.plugin import IPlugin
@@ -84,8 +84,8 @@ class TxGSMService(Service):
         self.port.loseConnection()
 
 
+@implementer(IServiceMaker, IPlugin)
 class TxGSMServiceMaker(object):
-    implements(IServiceMaker, IPlugin)
     tapname = "txgsm"
     description = ("Utilities for talking to a GSM modem over USB via AT "
                    "commands.")


### PR DESCRIPTION
Fixes failing tests on python 3.

```
______________________________________________ ERROR collecting txgsm/tests/test_service.py ______________________________________________
txgsm/tests/test_service.py:4: in <module>
    from txgsm.service import TxGSMServiceMaker, TxGSMService, Options
txgsm/service.py:87: in <module>
    class TxGSMServiceMaker(object):
txgsm/service.py:88: in TxGSMServiceMaker
    implements(IServiceMaker, IPlugin)
../../.virtualenvs/txgsm-py3/lib/python3.4/site-packages/zope/interface/declarations.py:412: in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
E   TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.
```