### PR TITLE
Use python-messaging master .zip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - python: 3.5
 install:
   - pip install -U pip coveralls wheel
-  - pip install https://github.com/thijstriemstra/python-messaging/archive/master.zip
+  - pip install https://github.com/pmarti/python-messaging/archive/master.zip
   - pip install -r requirements-dev.txt
   - pip install -e .
   - flake8


### PR DESCRIPTION
My PR for python-messaging was recently merged so we can switch back to their master instead of my fork.
